### PR TITLE
Add simple three.js goat shooter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# GoatEnStein-GPT5
+# GoatEnStein
+
+GoatEnStein is a tiny first-person shooter built with [three.js](https://threejs.org/). Blast invading goats across two levels using either a pistol or an automatic rifle. You have five life points—run out and the game restarts.
+
+## Playing
+
+1. Serve the folder with any static file server. Using Node.js:
+
+```bash
+npm start
+```
+
+2. Open the displayed URL in a browser that supports ES modules.
+
+### Controls
+
+- **WASD**: Move
+- **Mouse**: Look around
+- **Mouse click**: Shoot
+- **1 / 2** or on‑screen buttons: Switch between pistol and rifle
+- Eliminate all goats, reach the green exit to advance.
+
+## Development
+
+The project uses three.js via CDN and has no build step. Modify `game.js` and `index.html` as needed.
+
+## License
+
+MIT

--- a/game.js
+++ b/game.js
@@ -1,0 +1,271 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
+
+let camera, scene, renderer, controls;
+let moveForward = false;
+let moveBackward = false;
+let moveLeft = false;
+let moveRight = false;
+let canShoot = true;
+let velocity = new THREE.Vector3();
+let direction = new THREE.Vector3();
+let prevTime = performance.now();
+let life = 5;
+let weapon = 'pistol';
+let lastShot = 0;
+let goats = [];
+let exitCube;
+let levelIndex = 0;
+let levelCleared = false;
+
+const levels = [
+  {
+    goats: [ {x:5,z:-5}, {x:-5,z:5} ],
+    exit: {x:10,z:0}
+  },
+  {
+    goats: [ {x:6,z:6}, {x:-6,z:-6}, {x:0,z:-8} ],
+    exit: {x:12,z:0}
+  }
+];
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x808080);
+
+  camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 1, 1000);
+
+  const canvas = document.getElementById('gameCanvas');
+  renderer = new THREE.WebGLRenderer({ canvas });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+
+  controls = new PointerLockControls(camera, canvas);
+
+  const blocker = document.getElementById('message');
+  blocker.style.display = 'block';
+  blocker.textContent = 'Click to start';
+  blocker.addEventListener('click', () => {
+    controls.lock();
+  });
+
+  controls.addEventListener('lock', () => {
+    blocker.style.display = 'none';
+  });
+
+  controls.addEventListener('unlock', () => {
+    blocker.style.display = 'block';
+    blocker.textContent = 'Paused';
+  });
+
+  scene.add(controls.getObject());
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444);
+  light.position.set(0, 200, 0);
+  scene.add(light);
+
+  const floorGeometry = new THREE.PlaneGeometry(100, 100, 10, 10);
+  const floorMaterial = new THREE.MeshBasicMaterial({ color: 0x707070 });
+  const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+  floor.rotation.x = -Math.PI / 2;
+  scene.add(floor);
+
+  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener('keyup', onKeyUp);
+  document.addEventListener('mousedown', () => shoot());
+  window.addEventListener('resize', onWindowResize);
+
+  document.getElementById('pistolBtn').addEventListener('click', () => { weapon='pistol'; updateUI(); });
+  document.getElementById('rifleBtn').addEventListener('click', () => { weapon='rifle'; updateUI(); });
+
+  initLevel(levels[levelIndex]);
+  updateUI();
+  animate();
+}
+
+function initLevel(level) {
+  goats.forEach(g => scene.remove(g));
+  goats = [];
+  if (exitCube) scene.remove(exitCube);
+  levelCleared = false;
+  controls.getObject().position.set(0, 2, 0);
+
+  level.goats.forEach(pos => createGoat(pos.x, pos.z));
+
+  const exitGeo = new THREE.BoxGeometry(2, 2, 2);
+  const exitMat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+  exitCube = new THREE.Mesh(exitGeo, exitMat);
+  exitCube.position.set(level.exit.x, 1, level.exit.z);
+  scene.add(exitCube);
+}
+
+function createGoat(x, z) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 64; canvas.height = 64;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, 64, 64);
+  ctx.font = '48px serif';
+  ctx.fillStyle = '#000';
+  ctx.fillText('🐐', 8, 48);
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.MeshBasicMaterial({ map: texture });
+  const geometry = new THREE.BoxGeometry(1, 1, 1);
+  const goat = new THREE.Mesh(geometry, material);
+  goat.position.set(x, 0.5, z);
+  scene.add(goat);
+  goats.push(goat);
+}
+
+function onKeyDown(event) {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW':
+      moveForward = true;
+      break;
+    case 'ArrowLeft':
+    case 'KeyA':
+      moveLeft = true;
+      break;
+    case 'ArrowDown':
+    case 'KeyS':
+      moveBackward = true;
+      break;
+    case 'ArrowRight':
+    case 'KeyD':
+      moveRight = true;
+      break;
+    case 'Digit1':
+      weapon = 'pistol';
+      updateUI();
+      break;
+    case 'Digit2':
+      weapon = 'rifle';
+      updateUI();
+      break;
+  }
+}
+
+function onKeyUp(event) {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW':
+      moveForward = false;
+      break;
+    case 'ArrowLeft':
+    case 'KeyA':
+      moveLeft = false;
+      break;
+    case 'ArrowDown':
+    case 'KeyS':
+      moveBackward = false;
+      break;
+    case 'ArrowRight':
+    case 'KeyD':
+      moveRight = false;
+      break;
+  }
+}
+
+function shoot() {
+  const now = performance.now();
+  const rate = weapon === 'pistol' ? 500 : 100; // ms
+  if (now - lastShot < rate) return;
+  lastShot = now;
+  const raycaster = new THREE.Raycaster(
+    camera.getWorldPosition(new THREE.Vector3()),
+    camera.getWorldDirection(new THREE.Vector3())
+  );
+  const intersects = raycaster.intersectObjects(goats);
+  if (intersects.length > 0) {
+    const goat = intersects[0].object;
+    scene.remove(goat);
+    goats.splice(goats.indexOf(goat), 1);
+    if (goats.length === 0) {
+      levelCleared = true;
+      exitCube.material.color.set(0x00ff00);
+      showMessage('Exit opened!');
+    }
+  }
+}
+
+function updateUI() {
+  document.getElementById('life').textContent = `Life: ${life}`;
+  document.getElementById('weapon').textContent = `Weapon: ${weapon.charAt(0).toUpperCase()+weapon.slice(1)}`;
+}
+
+function showMessage(text) {
+  const el = document.getElementById('message');
+  el.textContent = text;
+  el.style.display = 'block';
+  setTimeout(() => { el.style.display = 'none'; }, 2000);
+}
+
+function restartGame() {
+  life = 5;
+  levelIndex = 0;
+  initLevel(levels[levelIndex]);
+  updateUI();
+  showMessage('Game Restarted');
+}
+
+function nextLevel() {
+  levelIndex++;
+  if (levelIndex >= levels.length) {
+    showMessage('You Win!');
+    levelIndex = 0;
+    setTimeout(() => restartGame(), 3000);
+  } else {
+    initLevel(levels[levelIndex]);
+    showMessage(`Level ${levelIndex+1}`);
+  }
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+
+  const time = performance.now();
+  const delta = (time - prevTime) / 1000;
+
+  velocity.x -= velocity.x * 10.0 * delta;
+  velocity.z -= velocity.z * 10.0 * delta;
+
+  direction.z = Number(moveForward) - Number(moveBackward);
+  direction.x = Number(moveRight) - Number(moveLeft);
+  direction.normalize();
+
+  if (moveForward || moveBackward) velocity.z -= direction.z * 400.0 * delta;
+  if (moveLeft || moveRight) velocity.x -= direction.x * 400.0 * delta;
+
+  controls.moveRight(-velocity.x * delta);
+  controls.moveForward(-velocity.z * delta);
+
+  goats.forEach(goat => {
+    goat.rotation.y += 1 * delta;
+    if (goat.position.distanceTo(controls.getObject().position) < 1) {
+      life--;
+      updateUI();
+      scene.remove(goat);
+      goats.splice(goats.indexOf(goat),1);
+      if (life <= 0) {
+        showMessage('Game Over');
+        setTimeout(() => restartGame(), 3000);
+      }
+    }
+  });
+
+  if (levelCleared && controls.getObject().position.distanceTo(exitCube.position) < 1) {
+    levelCleared = false;
+    nextLevel();
+  }
+
+  renderer.render(scene, camera);
+  prevTime = time;
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GoatEnStein</title>
+  <style>
+    body { margin:0; overflow:hidden; }
+    canvas { display:block; }
+    #ui { position:absolute; top:10px; left:10px; color:#fff; font-family:sans-serif; z-index:100; }
+    #ui button { margin-right:5px; }
+    #message { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); color:white; font-size:2em; display:none; }
+  </style>
+</head>
+<body>
+  <canvas id="gameCanvas"></canvas>
+  <div id="ui">
+    <span id="life">Life: 5</span>
+    <span id="weapon">Weapon: Pistol</span>
+    <div>
+      <button id="pistolBtn">Pistol (1)</button>
+      <button id="rifleBtn">Rifle (2)</button>
+    </div>
+  </div>
+  <div id="message"></div>
+  <script type="module" src="game.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "goatenstein",
+  "version": "1.0.0",
+  "description": "Shoot goats in a simple three.js FPS",
+  "scripts": {
+    "start": "npx http-server .",
+    "test": "echo \"No tests specified\""
+  }
+}


### PR DESCRIPTION
## Summary
- create basic three.js FPS where you hunt goats instead of nazis
- add two levels, pistol and rifle weapons, life/restart logic
- document usage and controls in README
- fix rendering by adding a dedicated canvas and resize handling

## Testing
- `npm test`
- `node --check game.js` (no output)


------
https://chatgpt.com/codex/tasks/task_e_6895a5f9386c832fb7aa6a87b043ce1a